### PR TITLE
DFCxx -> SystemVerilog pipeline parametrization

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,7 +38,7 @@ int hlsMain(HlsContext &context) {
   auto kernel = start();
   bool useASAP = context.options.asapScheduler;
   kernel->compile(context.options.latConfig,
-                  context.options.outFile,
+                  {context.options.outFile},
                   (useASAP) ? dfcxx::Scheduler::ASAP 
                             : dfcxx::Scheduler::Linear);
   return 0;

--- a/src/model/dfcxx/include/dfcxx/kernel.h
+++ b/src/model/dfcxx/include/dfcxx/kernel.h
@@ -22,6 +22,7 @@
 #include "dfcxx/vars/var.h"
 
 #include <string_view>
+#include <vector>
 
 namespace dfcxx {
 
@@ -57,9 +58,8 @@ public:
 
   virtual std::string_view getName() = 0;
 
-  bool compile(const DFLatencyConfig &config, const Scheduler &sched);
-
-  bool compile(const DFLatencyConfig &config, const std::string &filePath,
+  bool compile(const DFLatencyConfig &config,
+               const std::vector<std::string> &outputPaths,
                const Scheduler &sched);
 };
 

--- a/src/model/dfcxx/include/dfcxx/typedefs.h
+++ b/src/model/dfcxx/include/dfcxx/typedefs.h
@@ -61,4 +61,7 @@ enum Scheduler {
 
 typedef std::unordered_map<dfcxx::Ops, unsigned> DFLatencyConfig;
 
+// Macro substitutions for indexes in a std::vector for paths.
+#define SV_OUT_ID 0
+
 #endif // DFCXX_TYPEDEFS_H

--- a/src/model/dfcxx/includeDev/dfcxx/converter.h
+++ b/src/model/dfcxx/includeDev/dfcxx/converter.h
@@ -16,6 +16,8 @@
 
 #include <string>
 
+typedef std::vector<llvm::raw_fd_ostream *> OutputStreams;
+
 namespace dfcxx {
 
 class DFCIRConverter {
@@ -23,7 +25,8 @@ private:
   LatencyConfig config;
 public:
   explicit DFCIRConverter(const DFLatencyConfig &config);
-  bool convertAndPrint(mlir::ModuleOp module, llvm::raw_fd_ostream &out,
+  bool convertAndPrint(mlir::ModuleOp module,
+                       OutputStreams &outputStreams,
                        const Scheduler &sched);
 };
 

--- a/src/model/dfcxx/lib/dfcxx/converter.cpp
+++ b/src/model/dfcxx/lib/dfcxx/converter.cpp
@@ -22,7 +22,7 @@ DFCIRConverter::DFCIRConverter(const DFLatencyConfig &config) {
 }
 
 bool DFCIRConverter::convertAndPrint(mlir::ModuleOp module,
-                                     llvm::raw_fd_ostream &out,
+                                     OutputStreams &outputStreams,
                                      const Scheduler &sched) {
   mlir::MLIRContext *context = module.getContext();
   mlir::PassManager pm(context);
@@ -37,7 +37,7 @@ bool DFCIRConverter::convertAndPrint(mlir::ModuleOp module,
   }
   pm.addPass(circt::createLowerFIRRTLToHWPass());
   pm.addPass(circt::createLowerSeqToSVPass());
-  pm.addPass(circt::createExportVerilogPass(out));
+  pm.addPass(circt::createExportVerilogPass(*(outputStreams[SV_OUT_ID])));
   auto result = pm.run(module);
   return result.succeeded();
 }

--- a/test/model/dfcxx/addconst.cpp
+++ b/test/model/dfcxx/addconst.cpp
@@ -15,7 +15,7 @@ TEST(DFCxx, AddConstAddInt2Asap) {
   DFLatencyConfig config = {
           {dfcxx::ADD_INT, 2}
   };
-  EXPECT_EQ(kernel.compile(config, NULLDEVICE, dfcxx::ASAP), true);
+  EXPECT_EQ(kernel.compile(config, {NULLDEVICE}, dfcxx::ASAP), true);
 }
 
 TEST(DFCxx, AddConstAddInt2Linear) {
@@ -23,5 +23,5 @@ TEST(DFCxx, AddConstAddInt2Linear) {
   DFLatencyConfig config = {
           {dfcxx::ADD_INT, 2}
   };
-  EXPECT_EQ(kernel.compile(config, NULLDEVICE, dfcxx::Linear), true);
+  EXPECT_EQ(kernel.compile(config, {NULLDEVICE}, dfcxx::Linear), true);
 }

--- a/test/model/dfcxx/idct.cpp
+++ b/test/model/dfcxx/idct.cpp
@@ -17,7 +17,7 @@ TEST(DFCxx, IdctAsap) {
           {dfcxx::MUL_INT, 3},
           {dfcxx::SUB_INT, 1}
   };
-  EXPECT_EQ(kernel.compile(config, NULLDEVICE, dfcxx::ASAP), true);
+  EXPECT_EQ(kernel.compile(config, {NULLDEVICE}, dfcxx::ASAP), true);
 }
 
 // Issue #7 (https://github.com/ispras/utopia-hls/issues/7).
@@ -29,5 +29,5 @@ TEST(DFCxx, IdctAsap) {
 //           {dfcxx::MUL_INT, 3},
 //           {dfcxx::SUB_INT, 1}
 //   };
-//   EXPECT_EQ(kernel.compile(config, NULLDEVICE, dfcxx::Linear), true);
+//   EXPECT_EQ(kernel.compile(config, {NULLDEVICE}, dfcxx::Linear), true);
 // }

--- a/test/model/dfcxx/matrixmul2.cpp
+++ b/test/model/dfcxx/matrixmul2.cpp
@@ -16,7 +16,7 @@ TEST(DFCxx, MatrixMul2AddInt2MulInt3Asap) {
           {dfcxx::ADD_INT, 2},
           {dfcxx::MUL_INT, 3},
   };
-  EXPECT_EQ(kernel.compile(config, NULLDEVICE, dfcxx::ASAP), true);
+  EXPECT_EQ(kernel.compile(config, {NULLDEVICE}, dfcxx::ASAP), true);
 }
 
 TEST(DFCxx, MatrixMul2AddInt2MulInt3Linear) {
@@ -25,5 +25,5 @@ TEST(DFCxx, MatrixMul2AddInt2MulInt3Linear) {
           {dfcxx::ADD_INT, 2},
           {dfcxx::MUL_INT, 2},
   };
-  EXPECT_EQ(kernel.compile(config, NULLDEVICE, dfcxx::Linear), true);
+  EXPECT_EQ(kernel.compile(config, {NULLDEVICE}, dfcxx::Linear), true);
 }

--- a/test/model/dfcxx/movingsum.cpp
+++ b/test/model/dfcxx/movingsum.cpp
@@ -15,7 +15,7 @@ TEST(DFCxx, MovingSumAddInt2Asap) {
   DFLatencyConfig config = {
           {dfcxx::ADD_INT, 2}
   };
-  EXPECT_EQ(kernel.compile(config, NULLDEVICE, dfcxx::ASAP), true);
+  EXPECT_EQ(kernel.compile(config, {NULLDEVICE}, dfcxx::ASAP), true);
 }
 
 TEST(DFCxx, MovingSumAddInt2Linear) {
@@ -23,7 +23,7 @@ TEST(DFCxx, MovingSumAddInt2Linear) {
   DFLatencyConfig config = {
           {dfcxx::ADD_INT, 2}
   };
-  EXPECT_EQ(kernel.compile(config, NULLDEVICE, dfcxx::Linear), true);
+  EXPECT_EQ(kernel.compile(config, {NULLDEVICE}, dfcxx::Linear), true);
 }
 
 TEST(DFCxx, MovingSumAddInt8Asap) {
@@ -31,7 +31,7 @@ TEST(DFCxx, MovingSumAddInt8Asap) {
   DFLatencyConfig config = {
           {dfcxx::ADD_INT, 8}
   };
-  EXPECT_EQ(kernel.compile(config, NULLDEVICE, dfcxx::ASAP), true);
+  EXPECT_EQ(kernel.compile(config, {NULLDEVICE}, dfcxx::ASAP), true);
 }
 
 TEST(DFCxx, MovingSumAddInt8Linear) {
@@ -39,5 +39,5 @@ TEST(DFCxx, MovingSumAddInt8Linear) {
   DFLatencyConfig config = {
           {dfcxx::ADD_INT, 8}
   };
-  EXPECT_EQ(kernel.compile(config, NULLDEVICE, dfcxx::Linear), true);
+  EXPECT_EQ(kernel.compile(config, {NULLDEVICE}, dfcxx::Linear), true);
 }

--- a/test/model/dfcxx/muxmul.cpp
+++ b/test/model/dfcxx/muxmul.cpp
@@ -16,7 +16,7 @@ TEST(DFCxx, MuxMulAddInt2MulInt3Asap) {
           {dfcxx::ADD_INT, 2},
           {dfcxx::MUL_INT, 3}
   };
-  EXPECT_EQ(kernel.compile(config, NULLDEVICE, dfcxx::ASAP), true);
+  EXPECT_EQ(kernel.compile(config, {NULLDEVICE}, dfcxx::ASAP), true);
 }
 
 TEST(DFCxx, MuxMulAddInt2MulInt3Linear) {
@@ -25,5 +25,5 @@ TEST(DFCxx, MuxMulAddInt2MulInt3Linear) {
           {dfcxx::ADD_INT, 2},
           {dfcxx::MUL_INT, 3}
   };
-  EXPECT_EQ(kernel.compile(config, NULLDEVICE, dfcxx::Linear), true);
+  EXPECT_EQ(kernel.compile(config, {NULLDEVICE}, dfcxx::Linear), true);
 }

--- a/test/model/dfcxx/polynomial2.cpp
+++ b/test/model/dfcxx/polynomial2.cpp
@@ -16,7 +16,7 @@ TEST(DFCxx, Polynomial2AddInt2MulInt3Asap) {
           {dfcxx::ADD_INT, 2},
           {dfcxx::MUL_INT, 3}
   };
-  EXPECT_EQ(kernel.compile(config, NULLDEVICE, dfcxx::ASAP), true);
+  EXPECT_EQ(kernel.compile(config, {NULLDEVICE}, dfcxx::ASAP), true);
 }
 
 TEST(DFCxx, Polynomial2AddInt2MulInt3Linear) {
@@ -25,7 +25,7 @@ TEST(DFCxx, Polynomial2AddInt2MulInt3Linear) {
           {dfcxx::ADD_INT, 2},
           {dfcxx::MUL_INT, 3}
   };
-  EXPECT_EQ(kernel.compile(config, NULLDEVICE, dfcxx::Linear), true);
+  EXPECT_EQ(kernel.compile(config, {NULLDEVICE}, dfcxx::Linear), true);
 }
 
 TEST(DFCxx, Polynomial2AddInt8MulInt15Asap) {
@@ -34,7 +34,7 @@ TEST(DFCxx, Polynomial2AddInt8MulInt15Asap) {
           {dfcxx::ADD_INT, 8},
           {dfcxx::MUL_INT, 15}
   };
-  EXPECT_EQ(kernel.compile(config, NULLDEVICE, dfcxx::ASAP), true);
+  EXPECT_EQ(kernel.compile(config, {NULLDEVICE}, dfcxx::ASAP), true);
 }
 
 TEST(DFCxx, Polynomial2AddInt8MulInt15Linear) {
@@ -43,5 +43,5 @@ TEST(DFCxx, Polynomial2AddInt8MulInt15Linear) {
           {dfcxx::ADD_INT, 8},
           {dfcxx::MUL_INT, 15}
   };
-  EXPECT_EQ(kernel.compile(config, NULLDEVICE, dfcxx::Linear), true);
+  EXPECT_EQ(kernel.compile(config, {NULLDEVICE}, dfcxx::Linear), true);
 }

--- a/test/model/dfcxx/scalar3.cpp
+++ b/test/model/dfcxx/scalar3.cpp
@@ -16,7 +16,7 @@ TEST(DFCxx, Scalar3AddInt2MulInt3Asap) {
           {dfcxx::ADD_INT, 2},
           {dfcxx::MUL_INT, 3}
   };
-  EXPECT_EQ(kernel.compile(config, NULLDEVICE, dfcxx::ASAP), true);
+  EXPECT_EQ(kernel.compile(config, {NULLDEVICE}, dfcxx::ASAP), true);
 }
 
 TEST(DFCxx, Scalar3AddInt2MulInt3Linear) {
@@ -25,5 +25,5 @@ TEST(DFCxx, Scalar3AddInt2MulInt3Linear) {
           {dfcxx::ADD_INT, 2},
           {dfcxx::MUL_INT, 3}
   };
-  EXPECT_EQ(kernel.compile(config, NULLDEVICE, dfcxx::Linear), true);
+  EXPECT_EQ(kernel.compile(config, {NULLDEVICE}, dfcxx::Linear), true);
 }


### PR DESCRIPTION
Mentioned in #23 .

DFCxx now supports different output paths for different artifacts.
Now an output path for SystemVerilog has to be set explicitly (option `--out <PATH>`)