### PR TITLE
CLI output formats revamp

### DIFF
--- a/config.json
+++ b/config.json
@@ -3,6 +3,6 @@
     "config"         : "",
     "asap_scheduler" : false,
     "lp_scheduler"   : false,
-    "out"            : ""
+    "sv_out"         : ""
   }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,7 +38,7 @@ int hlsMain(HlsContext &context) {
   auto kernel = start();
   bool useASAP = context.options.asapScheduler;
   kernel->compile(context.options.latConfig,
-                  {context.options.outFile},
+                  context.options.outNames,
                   (useASAP) ? dfcxx::Scheduler::ASAP 
                             : dfcxx::Scheduler::Linear);
   return 0;

--- a/src/model/dfcxx/include/dfcxx/typedefs.h
+++ b/src/model/dfcxx/include/dfcxx/typedefs.h
@@ -10,6 +10,7 @@
 #define DFCXX_TYPEDEFS_H
 
 #include <unordered_map>
+#include <cstdint>
 
 namespace dfcxx {
 

--- a/src/model/dfcxx/include/dfcxx/typedefs.h
+++ b/src/model/dfcxx/include/dfcxx/typedefs.h
@@ -61,7 +61,9 @@ enum Scheduler {
 
 typedef std::unordered_map<dfcxx::Ops, unsigned> DFLatencyConfig;
 
-// Macro substitutions for indexes in a std::vector for paths.
+// Has to be incremented with every new output format.
+#define OUTPUT_FORMATS_COUNT 1
+// Macro substitutions for indexes in a std::vector for output paths.
 #define SV_OUT_ID 0
 
 #endif // DFCXX_TYPEDEFS_H

--- a/src/model/dfcxx/include/dfcxx/typedefs.h
+++ b/src/model/dfcxx/include/dfcxx/typedefs.h
@@ -57,13 +57,17 @@ enum Scheduler {
   ASAP
 };
 
+// Used for accessing specified output format paths.
+enum class OutputFormatID : uint8_t {
+  SystemVerilog = 0,
+  // Utility value. Constains the number of elements in the enum.
+  COUNT
+};
+
+#define OUT_FORMAT_ID_INT(id) static_cast<uint8_t>(dfcxx::OutputFormatID::id)
+
 } // namespace dfcxx
 
 typedef std::unordered_map<dfcxx::Ops, unsigned> DFLatencyConfig;
-
-// Has to be incremented with every new output format.
-#define OUTPUT_FORMATS_COUNT 1
-// Macro substitutions for indexes in a std::vector for output paths.
-#define SV_OUT_ID 0
 
 #endif // DFCXX_TYPEDEFS_H

--- a/src/model/dfcxx/lib/dfcxx/converter.cpp
+++ b/src/model/dfcxx/lib/dfcxx/converter.cpp
@@ -37,7 +37,8 @@ bool DFCIRConverter::convertAndPrint(mlir::ModuleOp module,
   }
   pm.addPass(circt::createLowerFIRRTLToHWPass());
   pm.addPass(circt::createLowerSeqToSVPass());
-  pm.addPass(circt::createExportVerilogPass(*(outputStreams[SV_OUT_ID])));
+  pm.addPass(circt::createExportVerilogPass(*(
+      outputStreams[OUT_FORMAT_ID_INT(SystemVerilog)])));
   auto result = pm.run(module);
   return result.succeeded();
 }

--- a/src/options.h
+++ b/src/options.h
@@ -160,18 +160,26 @@ struct HlsOptions final : public AppOptions {
   HlsOptions(AppOptions &parent):
       AppOptions(parent, HLS_CMD, "High-level synthesis"),
       // Initialize the output paths vector for every possible format.
-      outNames(OUTPUT_FORMATS_COUNT) {
-      
+      outNames(OUT_FORMAT_ID_INT(COUNT)) {
+
     // Named options.
-    options->add_option(CONFIG_ARG, latConfigFile, "JSON latency configuration path")
+    options->add_option(CONFIG_ARG,
+                        latConfigFile,
+                        "JSON latency configuration path")
         ->expected(1);
     
     auto schedGroup = options->add_option_group(SCHEDULER_GROUP);
-    schedGroup->add_flag(ASAP_SCHEDULER_FLAG, asapScheduler, "Use greedy as-soon-as-possible scheduler");
-    schedGroup->add_flag(LP_SCHEDULER_FLAG,   lpScheduler,   "Use Linear Programming scheduler");
+    schedGroup->add_flag(ASAP_SCHEDULER_FLAG,
+                         asapScheduler,
+                        "Use greedy as-soon-as-possible scheduler");
+    schedGroup->add_flag(LP_SCHEDULER_FLAG,
+                         lpScheduler,
+                         "Use Linear Programming scheduler");
     schedGroup->require_option(1); 
     auto outputGroup = options->add_option_group(OUTPUT_GROUP);
-    outputGroup->add_option(SV_OUT_ARG, outNames[SV_OUT_ID], "File path for SystemVerilog output");
+    outputGroup->add_option(SV_OUT_ARG,
+                            outNames[OUT_FORMAT_ID_INT(SystemVerilog)],
+                            "Path to output SystemVerilog module to");
     outputGroup->require_option();
   }
 
@@ -179,7 +187,7 @@ struct HlsOptions final : public AppOptions {
     get(json, CONFIG_JSON,         latConfigFile);
     get(json, ASAP_SCHEDULER_JSON, asapScheduler);
     get(json, LP_SCHEDULER_JSON,   lpScheduler);
-    get(json, SV_OUT_JSON,         outNames[SV_OUT_ID]);
+    get(json, SV_OUT_JSON,         outNames[OUT_FORMAT_ID_INT(SystemVerilog)]);
   }
 
   std::string latConfigFile;

--- a/src/options.h
+++ b/src/options.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+// Is needed for DFCxx output formats definitions and avaiable op. types.
 #include "dfcxx/typedefs.h"
 
 #include "CLI/CLI.hpp"
@@ -32,10 +33,9 @@
 
 #define HLS_ID_JSON "hls"
 #define CONFIG_JSON "config"
-#define SCHEDULER_JSON "scheduler"
 #define ASAP_SCHEDULER_JSON "asap_scheduler"
 #define LP_SCHEDULER_JSON "lp_scheduler"
-#define OUT_JSON "out"
+#define SV_OUT_JSON "sv_out"
 
 //===----------------------------------------------------------------------===//
 // CLI args/flags definitions
@@ -45,7 +45,8 @@
 #define SCHEDULER_GROUP "scheduler"
 #define ASAP_SCHEDULER_FLAG CLI_FLAG("a")
 #define LP_SCHEDULER_FLAG CLI_FLAG("l")
-#define OUT_ARG CLI_ARG("out")
+#define OUTPUT_GROUP "output"
+#define SV_OUT_ARG CLI_ARG("sv_out")
 
 //===----------------------------------------------------------------------===//
 
@@ -157,31 +158,33 @@ protected:
 struct HlsOptions final : public AppOptions {
 
   HlsOptions(AppOptions &parent):
-      AppOptions(parent, HLS_CMD, "High-level synthesis") {
-
+      AppOptions(parent, HLS_CMD, "High-level synthesis"),
+      // Initialize the output paths vector for every possible format.
+      outNames(OUTPUT_FORMATS_COUNT) {
+      
     // Named options.
     options->add_option(CONFIG_ARG, latConfigFile, "JSON latency configuration path")
-           ->expected(1);
+        ->expected(1);
     
     auto schedGroup = options->add_option_group(SCHEDULER_GROUP);
     schedGroup->add_flag(ASAP_SCHEDULER_FLAG, asapScheduler, "Use greedy as-soon-as-possible scheduler");
     schedGroup->add_flag(LP_SCHEDULER_FLAG,   lpScheduler,   "Use Linear Programming scheduler");
     schedGroup->require_option(1); 
-
-    options->add_option(OUT_ARG, outFile, "Output file path (default: standard output stream)")
-           ->expected(0, 1);
+    auto outputGroup = options->add_option_group(OUTPUT_GROUP);
+    outputGroup->add_option(SV_OUT_ARG, outNames[SV_OUT_ID], "File path for SystemVerilog output");
+    outputGroup->require_option();
   }
 
   void fromJson(Json json) override {
     get(json, CONFIG_JSON,         latConfigFile);
     get(json, ASAP_SCHEDULER_JSON, asapScheduler);
     get(json, LP_SCHEDULER_JSON,   lpScheduler);
-    get(json, OUT_JSON,            outFile);
+    get(json, SV_OUT_JSON,         outNames[SV_OUT_ID]);
   }
 
   std::string latConfigFile;
   DFLatencyConfig latConfig;
-  std::string outFile;
+  std::vector<std::string> outNames;
   bool asapScheduler;
   bool lpScheduler;
 };


### PR DESCRIPTION
In #24 DFCxx -> SystemVerilog translation pipeline was revamped to support different output formats. This Pull Request has the similar idea, but this time for Utopia HLS CLI.