### PR TITLE
Unscheduled DFCIR & SystemVerilog output path options revamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,16 +216,16 @@ The list of arguments for `hls`-mode is presented below:
 
 * `-h,--help`: *optional* flag; used to print the help-message about other arguments.
 * `--config <PATH>`: *required* filesystem-path option; used to specify the file for a JSON latency configuration file. Its format is presented in *JSON Configuration* section.
-* `--sv_out <PATH>`: *optional* filesystem-path option; used to specify the destination file for the output SystemVerilog to be generated in.
-* `--dfcir_out <PATH>`: *optional* filesystem-path option; used to specify the destination file for the output DFCIR to be generated in.
+* `--out-sv <PATH>`: *optional* filesystem-path option; used to specify the output SystemVerilog file.
+* `--out-dfcir <PATH>`: *optional* filesystem-path option; used to specify the output DFCIR file.
 * `-a` or `-l`: *required* flag; used to specify the chosen scheduling strategy - either as-soon-as-possible or linear programming. **Exactly one of these flags has to be specified**.
 
-**At least one of the `*_out` options has to be specified.**
+**At least one of the `out-*` options has to be specified.**
 
 Here is an example of an Utopia HLS CLI call:
 
 ```bash
-umain hls --config ~/utopia-user/config.json --sv_out ~/outFile.sv --dfcir_out ~/outFile2.mlir -a
+umain hls --config ~/utopia-user/config.json --out-sv ~/outFile.sv --out-dfcir ~/outFile2.mlir -a
 ```
 
 ### JSON Configuration
@@ -273,7 +273,7 @@ For example, given subdirectory `polynomial2`, the compilation and execution com
 ```bash
 cmake -S . -B build -G Ninja -DCMAKE_PREFIX_PATH=~/firtool-1.72.0 -DSRC_FILES="~/utopia-hls/examples/polynomial2/polynomial2.cpp"
 cmake --build build
-build/src/umain hls --config examples/polynomial2/polynomial2.json -a
+build/src/umain hls --config examples/polynomial2/polynomial2.json -a --out-sv output
 ```
 
 ## DFCxx Documentation

--- a/README.md
+++ b/README.md
@@ -216,13 +216,16 @@ The list of arguments for `hls`-mode is presented below:
 
 * `-h,--help`: *optional* flag; used to print the help-message about other arguments.
 * `--config <PATH>`: *required* filesystem-path option; used to specify the file for a JSON latency configuration file. Its format is presented in *JSON Configuration* section.
-* `--out <NAME>`: *optional* filesystem-path option; used to specify the destination file for the output SystemVerilog to be generated in. If the name isn't provided or the provided name is an empty string, standard output stream is used.
+* `--sv_out <PATH>`: *optional* filesystem-path option; used to specify the destination file for the output SystemVerilog to be generated in.
+* `--dfcir_out <PATH>`: *optional* filesystem-path option; used to specify the destination file for the output DFCIR to be generated in.
 * `-a` or `-l`: *required* flag; used to specify the chosen scheduling strategy - either as-soon-as-possible or linear programming. **Exactly one of these flags has to be specified**.
+
+**At least one of the `*_out` options has to be specified.**
 
 Here is an example of an Utopia HLS CLI call:
 
 ```bash
-umain hls --config ~/utopia-user/config.json --out ~/outFile -a
+umain hls --config ~/utopia-user/config.json --sv_out ~/outFile.sv --dfcir_out ~/outFile2.mlir -a
 ```
 
 ### JSON Configuration

--- a/src/model/dfcxx/include/dfcxx/typedefs.h
+++ b/src/model/dfcxx/include/dfcxx/typedefs.h
@@ -61,6 +61,7 @@ enum Scheduler {
 // Used for accessing specified output format paths.
 enum class OutputFormatID : uint8_t {
   SystemVerilog = 0,
+  DFCIR,
   // Utility value. Constains the number of elements in the enum.
   COUNT
 };

--- a/src/options.h
+++ b/src/options.h
@@ -35,8 +35,8 @@
 #define CONFIG_JSON "config"
 #define ASAP_SCHEDULER_JSON "asap_scheduler"
 #define LP_SCHEDULER_JSON "lp_scheduler"
-#define SV_OUT_JSON "sv_out"
-#define DFCIR_OUT_JSON "dfcir_out"
+#define OUT_SV_JSON "out_sv"
+#define OUT_DFCIR_JSON "out_dfcir"
 
 //===----------------------------------------------------------------------===//
 // CLI args/flags definitions
@@ -47,8 +47,8 @@
 #define ASAP_SCHEDULER_FLAG CLI_FLAG("a")
 #define LP_SCHEDULER_FLAG CLI_FLAG("l")
 #define OUTPUT_GROUP "output"
-#define SV_OUT_ARG CLI_ARG("sv_out")
-#define DFCIR_OUT_ARG CLI_ARG("dfcir_out")
+#define OUT_SV_ARG CLI_ARG("out-sv")
+#define OUT_DFCIR_ARG CLI_ARG("out-dfcir")
 
 //===----------------------------------------------------------------------===//
 
@@ -179,12 +179,12 @@ struct HlsOptions final : public AppOptions {
                          "Use Linear Programming scheduler");
     schedGroup->require_option(1); 
     auto outputGroup = options->add_option_group(OUTPUT_GROUP);
-    outputGroup->add_option(SV_OUT_ARG,
+    outputGroup->add_option(OUT_SV_ARG,
                             outNames[OUT_FORMAT_ID_INT(SystemVerilog)],
-                            "Path to output SystemVerilog module to");
-    outputGroup->add_option(DFCIR_OUT_ARG,
+                            "Path to output the SystemVerilog module");
+    outputGroup->add_option(OUT_DFCIR_ARG,
                             outNames[OUT_FORMAT_ID_INT(DFCIR)],
-                            "Path to output unscheduled DFCIR to");
+                            "Path to output unscheduled DFCIR");
     outputGroup->require_option();
   }
 
@@ -192,8 +192,8 @@ struct HlsOptions final : public AppOptions {
     get(json, CONFIG_JSON,         latConfigFile);
     get(json, ASAP_SCHEDULER_JSON, asapScheduler);
     get(json, LP_SCHEDULER_JSON,   lpScheduler);
-    get(json, SV_OUT_JSON,         outNames[OUT_FORMAT_ID_INT(SystemVerilog)]);
-    get(json, DFCIR_OUT_JSON,      outNames[OUT_FORMAT_ID_INT(DFCIR)]);
+    get(json, OUT_SV_JSON,         outNames[OUT_FORMAT_ID_INT(SystemVerilog)]);
+    get(json, OUT_DFCIR_JSON,      outNames[OUT_FORMAT_ID_INT(DFCIR)]);
   }
 
   std::string latConfigFile;

--- a/src/options.h
+++ b/src/options.h
@@ -36,6 +36,7 @@
 #define ASAP_SCHEDULER_JSON "asap_scheduler"
 #define LP_SCHEDULER_JSON "lp_scheduler"
 #define SV_OUT_JSON "sv_out"
+#define DFCIR_OUT_JSON "dfcir_out"
 
 //===----------------------------------------------------------------------===//
 // CLI args/flags definitions
@@ -47,6 +48,7 @@
 #define LP_SCHEDULER_FLAG CLI_FLAG("l")
 #define OUTPUT_GROUP "output"
 #define SV_OUT_ARG CLI_ARG("sv_out")
+#define DFCIR_OUT_ARG CLI_ARG("dfcir_out")
 
 //===----------------------------------------------------------------------===//
 
@@ -180,6 +182,9 @@ struct HlsOptions final : public AppOptions {
     outputGroup->add_option(SV_OUT_ARG,
                             outNames[OUT_FORMAT_ID_INT(SystemVerilog)],
                             "Path to output SystemVerilog module to");
+    outputGroup->add_option(DFCIR_OUT_ARG,
+                            outNames[OUT_FORMAT_ID_INT(DFCIR)],
+                            "Path to output unscheduled DFCIR to");
     outputGroup->require_option();
   }
 
@@ -188,6 +193,7 @@ struct HlsOptions final : public AppOptions {
     get(json, ASAP_SCHEDULER_JSON, asapScheduler);
     get(json, LP_SCHEDULER_JSON,   lpScheduler);
     get(json, SV_OUT_JSON,         outNames[OUT_FORMAT_ID_INT(SystemVerilog)]);
+    get(json, DFCIR_OUT_JSON,      outNames[OUT_FORMAT_ID_INT(DFCIR)]);
   }
 
   std::string latConfigFile;


### PR DESCRIPTION
Unscheduled DFCIR option requested in #25 was added. SystemVerilog output path is no longer the only output option, thus its strict requirement was removed from both `README.md` and the codebase.