### PR TITLE
Test fixes: additional `compile`-method overload

### DIFF
--- a/src/model/dfcxx/include/dfcxx/kernel.h
+++ b/src/model/dfcxx/include/dfcxx/kernel.h
@@ -61,6 +61,11 @@ public:
   bool compile(const DFLatencyConfig &config,
                const std::vector<std::string> &outputPaths,
                const Scheduler &sched);
+  
+  bool compile(const DFLatencyConfig &config,
+               const DFOutputPaths &outputPaths,
+               const Scheduler &sched);
+
 };
 
 } // namespace dfcxx

--- a/src/model/dfcxx/include/dfcxx/typedefs.h
+++ b/src/model/dfcxx/include/dfcxx/typedefs.h
@@ -9,8 +9,9 @@
 #ifndef DFCXX_TYPEDEFS_H
 #define DFCXX_TYPEDEFS_H
 
-#include <unordered_map>
 #include <cstdint>
+#include <string>
+#include <unordered_map>
 
 namespace dfcxx {
 
@@ -71,5 +72,6 @@ enum class OutputFormatID : uint8_t {
 } // namespace dfcxx
 
 typedef std::unordered_map<dfcxx::Ops, unsigned> DFLatencyConfig;
+typedef std::unordered_map<dfcxx::OutputFormatID, std::string> DFOutputPaths;
 
 #endif // DFCXX_TYPEDEFS_H

--- a/src/model/dfcxx/lib/dfcxx/kernel.cpp
+++ b/src/model/dfcxx/lib/dfcxx/kernel.cpp
@@ -68,5 +68,14 @@ bool Kernel::compile(const DFLatencyConfig &config,
   return result;
 }
 
-} // namespace dfcxx
+bool Kernel::compile(const DFLatencyConfig &config,
+                     const DFOutputPaths &outputPaths,
+                     const Scheduler &sched) {
+  std::vector<std::string> outPathsStrings(OUT_FORMAT_ID_INT(COUNT), "");
+  for (const auto &[id, path] : outputPaths) {
+    outPathsStrings[static_cast<uint8_t>(id)] = path;
+  }
+  return compile(config, outPathsStrings, sched);
+}
 
+} // namespace dfcxx

--- a/test/model/dfcxx/addconst.cpp
+++ b/test/model/dfcxx/addconst.cpp
@@ -10,12 +10,15 @@
 
 #include "gtest/gtest.h"
 
+static const DFOutputPaths nullDevicePath =
+    {{dfcxx::OutputFormatID::SystemVerilog, NULLDEVICE}};
+
 TEST(DFCxx, AddConstAddInt2Asap) {
   AddConst kernel;
   DFLatencyConfig config = {
           {dfcxx::ADD_INT, 2}
   };
-  EXPECT_EQ(kernel.compile(config, {NULLDEVICE}, dfcxx::ASAP), true);
+  EXPECT_EQ(kernel.compile(config, nullDevicePath, dfcxx::ASAP), true);
 }
 
 TEST(DFCxx, AddConstAddInt2Linear) {
@@ -23,5 +26,5 @@ TEST(DFCxx, AddConstAddInt2Linear) {
   DFLatencyConfig config = {
           {dfcxx::ADD_INT, 2}
   };
-  EXPECT_EQ(kernel.compile(config, {NULLDEVICE}, dfcxx::Linear), true);
+  EXPECT_EQ(kernel.compile(config, nullDevicePath, dfcxx::Linear), true);
 }

--- a/test/model/dfcxx/idct.cpp
+++ b/test/model/dfcxx/idct.cpp
@@ -10,6 +10,9 @@
 
 #include "gtest/gtest.h"
 
+static const DFOutputPaths nullDevicePath =
+    {{dfcxx::OutputFormatID::SystemVerilog, NULLDEVICE}};
+
 TEST(DFCxx, IdctAsap) {
   IDCT kernel;
   DFLatencyConfig config = {
@@ -17,7 +20,7 @@ TEST(DFCxx, IdctAsap) {
           {dfcxx::MUL_INT, 3},
           {dfcxx::SUB_INT, 1}
   };
-  EXPECT_EQ(kernel.compile(config, {NULLDEVICE}, dfcxx::ASAP), true);
+  EXPECT_EQ(kernel.compile(config, nullDevicePath, dfcxx::ASAP), true);
 }
 
 // Issue #7 (https://github.com/ispras/utopia-hls/issues/7).
@@ -29,5 +32,5 @@ TEST(DFCxx, IdctAsap) {
 //           {dfcxx::MUL_INT, 3},
 //           {dfcxx::SUB_INT, 1}
 //   };
-//   EXPECT_EQ(kernel.compile(config, {NULLDEVICE}, dfcxx::Linear), true);
+//   EXPECT_EQ(kernel.compile(config, nullDevicePath, dfcxx::Linear), true);
 // }

--- a/test/model/dfcxx/matrixmul2.cpp
+++ b/test/model/dfcxx/matrixmul2.cpp
@@ -10,13 +10,16 @@
 
 #include "gtest/gtest.h"
 
+static const DFOutputPaths nullDevicePath =
+    {{dfcxx::OutputFormatID::SystemVerilog, NULLDEVICE}};
+
 TEST(DFCxx, MatrixMul2AddInt2MulInt3Asap) {
   MatrixMul2 kernel;
   DFLatencyConfig config = {
           {dfcxx::ADD_INT, 2},
           {dfcxx::MUL_INT, 3},
   };
-  EXPECT_EQ(kernel.compile(config, {NULLDEVICE}, dfcxx::ASAP), true);
+  EXPECT_EQ(kernel.compile(config, nullDevicePath, dfcxx::ASAP), true);
 }
 
 TEST(DFCxx, MatrixMul2AddInt2MulInt3Linear) {
@@ -25,5 +28,5 @@ TEST(DFCxx, MatrixMul2AddInt2MulInt3Linear) {
           {dfcxx::ADD_INT, 2},
           {dfcxx::MUL_INT, 2},
   };
-  EXPECT_EQ(kernel.compile(config, {NULLDEVICE}, dfcxx::Linear), true);
+  EXPECT_EQ(kernel.compile(config, nullDevicePath, dfcxx::Linear), true);
 }

--- a/test/model/dfcxx/movingsum.cpp
+++ b/test/model/dfcxx/movingsum.cpp
@@ -10,12 +10,15 @@
 
 #include "gtest/gtest.h"
 
+static const DFOutputPaths nullDevicePath =
+    {{dfcxx::OutputFormatID::SystemVerilog, NULLDEVICE}};
+
 TEST(DFCxx, MovingSumAddInt2Asap) {
   MovingSum kernel;
   DFLatencyConfig config = {
           {dfcxx::ADD_INT, 2}
   };
-  EXPECT_EQ(kernel.compile(config, {NULLDEVICE}, dfcxx::ASAP), true);
+  EXPECT_EQ(kernel.compile(config, nullDevicePath, dfcxx::ASAP), true);
 }
 
 TEST(DFCxx, MovingSumAddInt2Linear) {
@@ -23,7 +26,7 @@ TEST(DFCxx, MovingSumAddInt2Linear) {
   DFLatencyConfig config = {
           {dfcxx::ADD_INT, 2}
   };
-  EXPECT_EQ(kernel.compile(config, {NULLDEVICE}, dfcxx::Linear), true);
+  EXPECT_EQ(kernel.compile(config, nullDevicePath, dfcxx::Linear), true);
 }
 
 TEST(DFCxx, MovingSumAddInt8Asap) {
@@ -31,7 +34,7 @@ TEST(DFCxx, MovingSumAddInt8Asap) {
   DFLatencyConfig config = {
           {dfcxx::ADD_INT, 8}
   };
-  EXPECT_EQ(kernel.compile(config, {NULLDEVICE}, dfcxx::ASAP), true);
+  EXPECT_EQ(kernel.compile(config, nullDevicePath, dfcxx::ASAP), true);
 }
 
 TEST(DFCxx, MovingSumAddInt8Linear) {
@@ -39,5 +42,5 @@ TEST(DFCxx, MovingSumAddInt8Linear) {
   DFLatencyConfig config = {
           {dfcxx::ADD_INT, 8}
   };
-  EXPECT_EQ(kernel.compile(config, {NULLDEVICE}, dfcxx::Linear), true);
+  EXPECT_EQ(kernel.compile(config, nullDevicePath, dfcxx::Linear), true);
 }

--- a/test/model/dfcxx/muxmul.cpp
+++ b/test/model/dfcxx/muxmul.cpp
@@ -10,13 +10,16 @@
 
 #include "gtest/gtest.h"
 
+static const DFOutputPaths nullDevicePath =
+    {{dfcxx::OutputFormatID::SystemVerilog, NULLDEVICE}};
+
 TEST(DFCxx, MuxMulAddInt2MulInt3Asap) {
   MuxMul kernel;
   DFLatencyConfig config = {
           {dfcxx::ADD_INT, 2},
           {dfcxx::MUL_INT, 3}
   };
-  EXPECT_EQ(kernel.compile(config, {NULLDEVICE}, dfcxx::ASAP), true);
+  EXPECT_EQ(kernel.compile(config, nullDevicePath, dfcxx::ASAP), true);
 }
 
 TEST(DFCxx, MuxMulAddInt2MulInt3Linear) {
@@ -25,5 +28,5 @@ TEST(DFCxx, MuxMulAddInt2MulInt3Linear) {
           {dfcxx::ADD_INT, 2},
           {dfcxx::MUL_INT, 3}
   };
-  EXPECT_EQ(kernel.compile(config, {NULLDEVICE}, dfcxx::Linear), true);
+  EXPECT_EQ(kernel.compile(config, nullDevicePath, dfcxx::Linear), true);
 }

--- a/test/model/dfcxx/polynomial2.cpp
+++ b/test/model/dfcxx/polynomial2.cpp
@@ -10,13 +10,16 @@
 
 #include "gtest/gtest.h"
 
+static const DFOutputPaths nullDevicePath =
+    {{dfcxx::OutputFormatID::SystemVerilog, NULLDEVICE}};
+
 TEST(DFCxx, Polynomial2AddInt2MulInt3Asap) {
   Polynomial2 kernel;
   DFLatencyConfig config = {
           {dfcxx::ADD_INT, 2},
           {dfcxx::MUL_INT, 3}
   };
-  EXPECT_EQ(kernel.compile(config, {NULLDEVICE}, dfcxx::ASAP), true);
+  EXPECT_EQ(kernel.compile(config, nullDevicePath, dfcxx::ASAP), true);
 }
 
 TEST(DFCxx, Polynomial2AddInt2MulInt3Linear) {
@@ -25,7 +28,7 @@ TEST(DFCxx, Polynomial2AddInt2MulInt3Linear) {
           {dfcxx::ADD_INT, 2},
           {dfcxx::MUL_INT, 3}
   };
-  EXPECT_EQ(kernel.compile(config, {NULLDEVICE}, dfcxx::Linear), true);
+  EXPECT_EQ(kernel.compile(config, nullDevicePath, dfcxx::Linear), true);
 }
 
 TEST(DFCxx, Polynomial2AddInt8MulInt15Asap) {
@@ -34,7 +37,7 @@ TEST(DFCxx, Polynomial2AddInt8MulInt15Asap) {
           {dfcxx::ADD_INT, 8},
           {dfcxx::MUL_INT, 15}
   };
-  EXPECT_EQ(kernel.compile(config, {NULLDEVICE}, dfcxx::ASAP), true);
+  EXPECT_EQ(kernel.compile(config, nullDevicePath, dfcxx::ASAP), true);
 }
 
 TEST(DFCxx, Polynomial2AddInt8MulInt15Linear) {
@@ -43,5 +46,5 @@ TEST(DFCxx, Polynomial2AddInt8MulInt15Linear) {
           {dfcxx::ADD_INT, 8},
           {dfcxx::MUL_INT, 15}
   };
-  EXPECT_EQ(kernel.compile(config, {NULLDEVICE}, dfcxx::Linear), true);
+  EXPECT_EQ(kernel.compile(config, nullDevicePath, dfcxx::Linear), true);
 }

--- a/test/model/dfcxx/scalar3.cpp
+++ b/test/model/dfcxx/scalar3.cpp
@@ -10,13 +10,16 @@
 
 #include "gtest/gtest.h"
 
+static const DFOutputPaths nullDevicePath =
+    {{dfcxx::OutputFormatID::SystemVerilog, NULLDEVICE}};
+
 TEST(DFCxx, Scalar3AddInt2MulInt3Asap) {
   Scalar3 kernel;
   DFLatencyConfig config = {
           {dfcxx::ADD_INT, 2},
           {dfcxx::MUL_INT, 3}
   };
-  EXPECT_EQ(kernel.compile(config, {NULLDEVICE}, dfcxx::ASAP), true);
+  EXPECT_EQ(kernel.compile(config, nullDevicePath, dfcxx::ASAP), true);
 }
 
 TEST(DFCxx, Scalar3AddInt2MulInt3Linear) {
@@ -25,5 +28,5 @@ TEST(DFCxx, Scalar3AddInt2MulInt3Linear) {
           {dfcxx::ADD_INT, 2},
           {dfcxx::MUL_INT, 3}
   };
-  EXPECT_EQ(kernel.compile(config, {NULLDEVICE}, dfcxx::Linear), true);
+  EXPECT_EQ(kernel.compile(config, nullDevicePath, dfcxx::Linear), true);
 }


### PR DESCRIPTION
As described in #32, tests were broken ever since the Pull Request with additional output formats.
This pull request fixes the issue by adding a "user level"-overload for `compile`, which allows to retain the original structure of tests when additional output formats are being added.

Now output paths can be specified with an `unordered map<dfcxx::OutputFormatID, std::string>` alias, `DFOutputPaths`.