### PR TITLE
GTest version changed from 1.11.0 to 1.14.0; fixed Clang compilation

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,7 +13,7 @@ if(NOT TARGET GTest::gtest)
   FetchContent_Declare(
     googletest
     GIT_REPOSITORY https://github.com/google/googletest.git
-    GIT_TAG        release-1.11.0)
+    GIT_TAG        v1.14.0)
 
   # For Windows: Prevent overriding the parent project's compiler/linker settings.
   set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)


### PR DESCRIPTION
Turns out bumping the GTest version up to 1.14.0 (the same is used in Utopia EDA) fixes the Clang compilation error from #30.

To test it out add the following string to any Utopia HLS compilation command (`clang++` is a OS-dependent name):

```
-DCMAKE_CXX_COMPILER=clang++
```
For example:

```
cmake -S . -B build -G Ninja -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_PREFIX_PATH="~/circt72/build;~/circt72/llvm/build" -DSRC_FILES=~/utopia-hls/examples/polynomial2/polynomial2.cpp -DBUILD_TESTS=ON
```
