### PR TITLE
Output format tests for SystemVerilog and DFCIR

### DIFF
--- a/test/model/dfcxx/output_formats.cpp
+++ b/test/model/dfcxx/output_formats.cpp
@@ -15,9 +15,35 @@ static const Polynomial2 kernel;
 static const DFLatencyConfig config =
     {{dfcxx::ADD_INT, 2}, {dfcxx::MUL_INT, 3}};
 
+TEST(DFCxxOutputFormats, SystemVerilog) {
+  Polynomial2 kernel;
+  DFOutputPaths paths = {
+    {dfcxx::OutputFormatID::SystemVerilog, NULLDEVICE}
+  };
+  EXPECT_EQ(kernel.compile(config, paths, dfcxx::ASAP), true);
+}
+
+TEST(DFCxxOutputFormats, DFCIR) {
+  Polynomial2 kernel;
+  DFOutputPaths paths = {
+    {dfcxx::OutputFormatID::DFCIR, NULLDEVICE}
+  };
+  EXPECT_EQ(kernel.compile(config, paths, dfcxx::ASAP), true);
+}
+
 TEST(DFCxxOutputFormats, FIRRTL) {
   Polynomial2 kernel;
   DFOutputPaths paths = {
+    {dfcxx::OutputFormatID::FIRRTL, NULLDEVICE}
+  };
+  EXPECT_EQ(kernel.compile(config, paths, dfcxx::ASAP), true);
+}
+
+TEST(DFCxxOutputFormats, All) {
+  Polynomial2 kernel;
+  DFOutputPaths paths = {
+    {dfcxx::OutputFormatID::SystemVerilog, NULLDEVICE},
+    {dfcxx::OutputFormatID::DFCIR, NULLDEVICE},
     {dfcxx::OutputFormatID::FIRRTL, NULLDEVICE}
   };
   EXPECT_EQ(kernel.compile(config, paths, dfcxx::ASAP), true);


### PR DESCRIPTION
In #40 first output test (for FIRRTL) was added. This Pull Request adds three more tests for previously existing formats. With every new format additional tests will be added.