### PR TITLE
CLI, DFCxx, DFCIR: command line fixes & minor tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Unless neither of the three arguments is used, first argument is the mode which 
 * `--out-sv <PATH>`: *optional* filesystem-path option; used to specify the output SystemVerilog file (default if option specified with no `<PATH>`: `output.sv`).
 * `--out-sv-lib <PATH>`: *optional* filesystem-path option; used to specify the output SystemVerilog file for generated operations library (default if option specified with no `<PATH>`: `output-lib.sv`).
 * `--out-dfcir <PATH>`: *optional* filesystem-path option; used to specify the output unscheduled DFCIR file (default if option specified with no `<PATH>`: `dfcir.mlir`).
-* `--out-scheduled-dfcir <PATH>`: *optional* filesystem-path option; used to specify the output scheduled DFCIR file (default if option specified with no `<PATH>`: `scheduler-dfcir.mlir`).
+* `--out-scheduled-dfcir <PATH>`: *optional* filesystem-path option; used to specify the output scheduled DFCIR file (default if option specified with no `<PATH>`: `scheduled-dfcir.mlir`).
 * `--out-firrtl <PATH>`: *optional* filesystem-path option; used to specify the output FIRRTL file (default if option specified with no `<PATH>`: `firrtl.mlir`).
 * `--out-dot <PATH>`: *optional* filesystem-path option; used to specify the output DOT file (default if option specified with no `<PATH>`: `output.dot`).
 * `-a` or `-l` or `--pipeline <STAGES>`: *optional* flag/option; used to specify the chosen scheduling strategy - either as-soon-as-possible or linear programming or combinational pipelining for the provided number of stages (default: `--pipeline 0`). **Exactly one or zero of these flags has to be specified**.

--- a/README.md
+++ b/README.md
@@ -180,14 +180,14 @@ Unless neither of the three arguments is used, first argument is the mode which 
 `hls` mode is used to perform the high-level synthesis of digital hardware description from the input DFCxx kernel. The list of arguments for `hls`-mode is presented below:
 
 * `-h,--help`: *optional* flag; used to print the help-message about other arguments.
-* `--config <PATH>`: *required* filesystem-path option; used to specify the file for a JSON latency configuration file. Its format is presented in `docs/latency_config.md`.
-* `--out-sv <PATH>`: *optional* filesystem-path option; used to specify the output SystemVerilog file.
-* `--out-sv-lib <PATH>`: *optional* filesystem-path option; used to specify the output SystemVerilog file for generated operations library.
-* `--out-dfcir <PATH>`: *optional* filesystem-path option; used to specify the output unscheduled DFCIR file.
-* `--out-scheduled-dfcir <PATH>`: *optional* filesystem-path option; used to specify the output scheduled DFCIR file.
-* `--out-firrtl <PATH>`: *optional* filesystem-path option; used to specify the output FIRRTL file.
-* `--out-dot <PATH>`: *optional* filesystem-path option; used to specify the output DOT file.
-* `-a` or `-l`: *required* flag; used to specify the chosen scheduling strategy - either as-soon-as-possible or linear programming. **Exactly one of these flags has to be specified**.
+* `--config <PATH>`: *optional* filesystem-path option; used to specify the file for a JSON latency configuration file (default if option specified with no `<PATH>`: `latency.json`). Its format is presented in `docs/latency_config.md`.
+* `--out-sv <PATH>`: *optional* filesystem-path option; used to specify the output SystemVerilog file (default if option specified with no `<PATH>`: `output.sv`).
+* `--out-sv-lib <PATH>`: *optional* filesystem-path option; used to specify the output SystemVerilog file for generated operations library (default if option specified with no `<PATH>`: `output-lib.sv`).
+* `--out-dfcir <PATH>`: *optional* filesystem-path option; used to specify the output unscheduled DFCIR file (default if option specified with no `<PATH>`: `dfcir.mlir`).
+* `--out-scheduled-dfcir <PATH>`: *optional* filesystem-path option; used to specify the output scheduled DFCIR file (default if option specified with no `<PATH>`: `scheduler-dfcir.mlir`).
+* `--out-firrtl <PATH>`: *optional* filesystem-path option; used to specify the output FIRRTL file (default if option specified with no `<PATH>`: `firrtl.mlir`).
+* `--out-dot <PATH>`: *optional* filesystem-path option; used to specify the output DOT file (default if option specified with no `<PATH>`: `output.dot`).
+* `-a` or `-l` or `--pipeline <STAGES>`: *optional* flag/option; used to specify the chosen scheduling strategy - either as-soon-as-possible or linear programming or combinational pipelining for the provided number of stages (default: `--pipeline 0`). **Exactly one or zero of these flags has to be specified**.
 
 **At least one of the `out-*` options has to be specified.**
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -46,19 +46,9 @@ int hlsMain(const HlsContext &context) {
   auto kernel = start();
   if (!kernel->check()) { return 1; }
 
-  dfcxx::DFOptionsConfig optionsCfg = context.options.optionsCfg;
-
-  if (context.options.asapScheduler) {
-    optionsCfg.scheduler = dfcxx::Scheduler::ASAP;
-  } else if (context.options.lpScheduler) {
-    optionsCfg.scheduler = dfcxx::Scheduler::Linear;
-  } else {
-    optionsCfg.scheduler = dfcxx::Scheduler::CombPipelining;
-  }
-
   return !kernel->compile(context.options.latencyCfg,
                           context.options.outNames,
-                          optionsCfg);
+                          context.options.optionsCfg);
 }
 
 int simMain(const SimContext &context) {

--- a/src/model/dfcir/include/dfcir/DFCIROpInterfaces.td
+++ b/src/model/dfcir/include/dfcir/DFCIROpInterfaces.td
@@ -77,11 +77,33 @@ def Scheduled : OpInterface<"Scheduled"> {
       /*defaultImplementation=*/[{}]
     >,
     InterfaceMethod<
+      "Get positive clock latency (or 0 if not set).",
+      "int32_t",
+      "getPosLatency",
+      (ins),
+      /*methodBody=*/[{
+        int32_t latency = getLatency(impl, $_op);
+        return (latency >= 0) ? latency : 0;
+      }],
+      /*defaultImplementation=*/[{}]
+    >,
+    InterfaceMethod<
       "Get clock latency as an attribute.",
       "mlir::IntegerAttr",
       "getLatencyAttr",
       (ins),
       /*methodBody=*/[{ return $_op.getLatencyAttr(); }],
+      /*defaultImplementation=*/[{}]
+    >,
+    InterfaceMethod<
+      "Get positive clock latency as an attribute.",
+      "mlir::IntegerAttr",
+      "getPosLatencyAttr",
+      (ins),
+      /*methodBody=*/[{
+        return mlir::IntegerAttr::get(IntegerType::get($_op.getContext(), 32),
+                                      getPosLatency(impl, $_op));
+      }],
       /*defaultImplementation=*/[{}]
     >,
     InterfaceMethod<

--- a/src/model/dfcir/lib/dfcir/passes/DFCIRCombPipelinePass.cpp
+++ b/src/model/dfcir/lib/dfcir/passes/DFCIRCombPipelinePass.cpp
@@ -30,6 +30,9 @@ public:
   using LayerCascades = utils::CombGraph::LayerCascades;
 
   void runOnOperation() override {
+    // No need to do any pipelining for 0 stages.
+    if (!stages) { return; }
+
     // Convert kernel into graph.
     CombGraph graph;
     graph.constructFrom(llvm::cast<ModuleOp>(getOperation()));

--- a/src/model/dfcir/lib/dfcir/passes/DFCIRToFIRRTLPass.cpp
+++ b/src/model/dfcir/lib/dfcir/passes/DFCIRToFIRRTLPass.cpp
@@ -395,7 +395,8 @@ class SchedulableOpConversionPattern
       llvm::cast<SVSynthesizable>(innerType).printSVSignature(nameStream);
     }
 
-    nameStream << "_" << llvm::cast<Scheduled>(op.getOperation()).getLatency();
+    nameStream << "_"
+               << llvm::cast<Scheduled>(op.getOperation()).getPosLatency();
 
     return name;
   }
@@ -422,7 +423,7 @@ class SchedulableOpConversionPattern
     IntegerType attrType = mlir::IntegerType::get(rewriter.getContext(), 32,
                                                   mlir::IntegerType::Unsigned);
 
-    int32_t latency = llvm::cast<Scheduled>(op.getOperation()).getLatency();
+    int32_t latency = llvm::cast<Scheduled>(op.getOperation()).getPosLatency();
     auto module = rewriter.create<FExtModuleOp>(
         rewriter.getUnknownLoc(),
         mlir::StringAttr::get(rewriter.getContext(), name),
@@ -1019,7 +1020,7 @@ public:
 
     auto convertedType = getTypeConverter()->convertType(op->getResult(0).getType());
     auto width = getBitWidth(llvm::dyn_cast<FIRRTLBaseType>(convertedType));
-    int32_t latency = llvm::cast<Scheduled>(op.getOperation()).getLatency();
+    int32_t latency = llvm::cast<Scheduled>(op.getOperation()).getPosLatency();
     nameStream << "_IN_" << *width << "_OUT_" << *width << "_" << latency;
 
     return name;

--- a/src/model/dfcxx/include/dfcxx/typedefs.h
+++ b/src/model/dfcxx/include/dfcxx/typedefs.h
@@ -17,8 +17,10 @@
 namespace dfcxx {
 
 enum Ops {
+  // Empty op. Its latency is always 0.
+  UNDEFINED,
   // Arithmetic operations.
-  ADD_INT = 1,
+  ADD_INT,
   ADD_FLOAT,
   SUB_INT,
   SUB_FLOAT,
@@ -89,23 +91,11 @@ public:
   uint64_t stages;
 
   DFOptionsConfig() {
-    scheduler = Scheduler::ASAP;
+    scheduler = Scheduler::CombPipelining;
     stages = 0;
   }
 
   DFOptionsConfig(const DFOptionsConfig &) = default;
-
-  std::string validate() const {
-    if (scheduler != Scheduler::CombPipelining && stages > 0) {
-      return "Pipeline stages cannot be specified without pipelining scheduler.";
-    }
-
-    if (scheduler == Scheduler::CombPipelining && stages == 0) {
-      return "Pipeline stages were not specified along with pipelining sheduler.";
-    }
-
-    return "";
-  }
 };
 
 } // namespace dfcxx

--- a/src/model/dfcxx/lib/dfcxx/kernel.cpp
+++ b/src/model/dfcxx/lib/dfcxx/kernel.cpp
@@ -179,12 +179,6 @@ void Kernel::deleteNode(Node *node) {
 bool Kernel::compile(const DFLatencyConfig &config,
                      const std::vector<std::string> &outputPaths,
                      const DFOptionsConfig &options) {
-  std::string errString = options.validate();
-  if (!errString.empty()) {
-    std::cout << "Options: " << errString << std::endl;
-    return false;
-  }
-
   DFCIRBuilder builder;
   auto compiled = builder.buildModule(this);
   size_t count = outputPaths.size();

--- a/src/options.h
+++ b/src/options.h
@@ -205,22 +205,24 @@ struct HlsOptions final : public AppOptions {
       outNames(OUT_FORMAT_ID_INT(COUNT)) {
 
     // Named options.
-    options->add_option(CONFIG_ARG,
-                        latencyCfgFile,
-                        "JSON latency configuration path")
-           ->default_str(CONFIG_ARG_DEFAULT)
-           ->expected(0, 1);
+    options
+        ->add_option(CONFIG_ARG,
+                     latencyCfgFile,
+                     "JSON latency configuration path")
+        ->default_str(CONFIG_ARG_DEFAULT)
+        ->expected(0, 1);
     
     auto schedGroup = options->add_option_group(SCHEDULER_GROUP);
     schedGroup->add_flag(ASAP_SCHEDULER_FLAG,
                          "Use greedy as-soon-as-possible scheduler");
     schedGroup->add_flag(LP_SCHEDULER_FLAG,
                          "Use Linear Programming scheduler");
-    schedGroup->add_option(PIPELINE_SCHEDULER_ARG,
-                           optionsCfg.stages,
-                           "Use Combinational Pipelining scheduler with the specified pipeline stages")
-              ->capture_default_str()
-              ->expected(0, 1);
+    schedGroup
+        ->add_option(PIPELINE_SCHEDULER_ARG,
+                     optionsCfg.stages,
+                     "Use Combinational Pipelining scheduler with the specified pipeline stages")
+        ->capture_default_str()
+        ->expected(0, 1);
     schedGroup->require_option(0, 1);
 
     // The callback below is used to set correct optionsCfg.scheduler enum value.
@@ -244,36 +246,42 @@ struct HlsOptions final : public AppOptions {
     });
 
     auto outputGroup = options->add_option_group(OUTPUT_GROUP);
-    outputGroup->add_option(OUT_SV_ARG,
-                            outNames[OUT_FORMAT_ID_INT(SystemVerilog)],
-                            "Path to output the SystemVerilog module")
-               ->default_str(OUT_SV_ARG_DEFAULT)
-               ->expected(0, 1);
-    outputGroup->add_option(OUT_SV_LIB_ARG,
-                            outNames[OUT_FORMAT_ID_INT(SVLibrary)],
-                            "Path to output SystemVerilog modules for generated operations")
-               ->default_str(OUT_SV_LIB_ARG_DEFAULT)
-               ->expected(0, 1);
-    outputGroup->add_option(OUT_UNSCHEDULED_DFCIR_ARG,
-                            outNames[OUT_FORMAT_ID_INT(UnscheduledDFCIR)],
-                            "Path to output unscheduled DFCIR")
-               ->default_str(OUT_UNSCHEDULED_DFCIR_ARG_DEFAULT)
-               ->expected(0, 1);
-    outputGroup->add_option(OUT_SCHEDULED_DFCIR_ARG,
-                            outNames[OUT_FORMAT_ID_INT(ScheduledDFCIR)],
-                            "Path to output scheduled DFCIR")
-               ->default_str(OUT_SCHEDULED_DFCIR_ARG_DEFAULT)
-               ->expected(0, 1);
-    outputGroup->add_option(OUT_FIRRTL_ARG,
-                            outNames[OUT_FORMAT_ID_INT(FIRRTL)],
-                            "Path to output scheduled FIRRTL")
-               ->default_str(OUT_FIRRTL_ARG_DEFAULT)
-               ->expected(0, 1);
-    outputGroup->add_option(OUT_DOT_ARG,
-                            outNames[OUT_FORMAT_ID_INT(DOT)],
-                            "Path to output a DFCxx kernel in DOT format.")
-               ->default_str(OUT_DOT_ARG_DEFAULT)
-               ->expected(0, 1);
+    outputGroup
+        ->add_option(OUT_SV_ARG,
+                     outNames[OUT_FORMAT_ID_INT(SystemVerilog)],
+                     "Path to output the SystemVerilog module")
+        ->default_str(OUT_SV_ARG_DEFAULT)
+        ->expected(0, 1);
+    outputGroup
+         ->add_option(OUT_SV_LIB_ARG,
+                      outNames[OUT_FORMAT_ID_INT(SVLibrary)],
+                      "Path to output SystemVerilog modules for generated operations")
+         ->default_str(OUT_SV_LIB_ARG_DEFAULT)
+         ->expected(0, 1);
+    outputGroup
+         ->add_option(OUT_UNSCHEDULED_DFCIR_ARG,
+                      outNames[OUT_FORMAT_ID_INT(UnscheduledDFCIR)],
+                      "Path to output unscheduled DFCIR")
+         ->default_str(OUT_UNSCHEDULED_DFCIR_ARG_DEFAULT)
+         ->expected(0, 1);
+    outputGroup
+        ->add_option(OUT_SCHEDULED_DFCIR_ARG,
+                     outNames[OUT_FORMAT_ID_INT(ScheduledDFCIR)],
+                     "Path to output scheduled DFCIR")
+        ->default_str(OUT_SCHEDULED_DFCIR_ARG_DEFAULT)
+        ->expected(0, 1);
+    outputGroup
+        ->add_option(OUT_FIRRTL_ARG,
+                     outNames[OUT_FORMAT_ID_INT(FIRRTL)],
+                     "Path to output scheduled FIRRTL")
+        ->default_str(OUT_FIRRTL_ARG_DEFAULT)
+        ->expected(0, 1);
+    outputGroup
+        ->add_option(OUT_DOT_ARG,
+                     outNames[OUT_FORMAT_ID_INT(DOT)],
+                     "Path to output a DFCxx kernel in DOT format.")
+        ->default_str(OUT_DOT_ARG_DEFAULT)
+        ->expected(0, 1);
     outputGroup->require_option();
   }
 
@@ -342,16 +350,18 @@ struct SimOptions final : public AppOptions {
       AppOptions(parent, SIM_CMD, "DFCxx simulation") {
     
     // Named options.
-    options->add_option(SIM_IN_ARG,
-                        inFilePath,
-                        "Simulation input data path")
-           ->default_str(SIM_IN_ARG_DEFAULT)
-           ->expected(0, 1);
-    options->add_option(SIM_OUT_ARG,
-                        outFilePath,
-                        "Simulation results output path")
-           ->default_str(SIM_OUT_ARG_DEFAULT)
-           ->expected(0, 1);
+    options
+        ->add_option(SIM_IN_ARG,
+                     inFilePath,
+                     "Simulation input data path")
+        ->default_str(SIM_IN_ARG_DEFAULT)
+        ->expected(0, 1);
+    options
+        ->add_option(SIM_OUT_ARG,
+                     outFilePath,
+                     "Simulation results output path")
+        ->default_str(SIM_OUT_ARG_DEFAULT)
+        ->expected(0, 1);
   }
 
   void fromJson(Json json) override {


### PR DESCRIPTION
This Merge Request introduces the following changes:
- [x] CLI options default values are now specified in CLI11 API (no need for `config.json`); 
- [x] Latency config became an option rather than a requirement;
- [x] DFCIROpInterfaces.td: added `getPosLatency(Attr)` methods, which are now used in `DFCIRToFIRRTLPass` instead of old `getLatency(Attr)` methods (graph nodes without assigned latencies are implicitly assigned latency 0);
- [x] DFCxx: added enumeration value `dfcxx::Ops::UNDEFINED` to synchronize with `dfcir::Ops`;
- [x] `DFCIRCombPipeliningPass`: Added `stages == 0` check;
- [x] `README.md` updates according to the introduces changes.